### PR TITLE
fix: replace the crontab each boot

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -25,7 +25,7 @@ if [[ $OPTION = "start" ]]; then
   CRONFILE="/etc/cron.d/s3sync"
   CRONENV=""
 
-  echo "Found the following files and directores mounted under /data:"
+  echo "Found the following files and directories mounted under /data:"
   echo
   ls -F /data
   echo
@@ -36,7 +36,7 @@ if [[ $OPTION = "start" ]]; then
   CRONENV="$CRONENV AWS_DEFAULT_REGION=$REGION"
   CRONENV="$CRONENV S3PATH=$S3PATH"
   CRONENV="$CRONENV S3SYNCPARAMS=\"$S3SYNCPARAMS\""
-  echo "$CRON_SCHEDULE root $CRONENV bash /run.sh backup" >> $CRONFILE
+  echo "$CRON_SCHEDULE root $CRONENV bash /run.sh backup" > $CRONFILE
 
   echo "Starting CRON scheduler: $(date)"
   cron


### PR DESCRIPTION
At the moment, if you restart the container for any reason it will create multiple cron entries which conflict with each other.