### PR TITLE
Overwrite crontab instead of appending to it

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -36,7 +36,7 @@ if [[ $OPTION = "start" ]]; then
   CRONENV="$CRONENV AWS_DEFAULT_REGION=$REGION"
   CRONENV="$CRONENV S3PATH=$S3PATH"
   CRONENV="$CRONENV S3SYNCPARAMS=\"$S3SYNCPARAMS\""
-  echo "$CRON_SCHEDULE root $CRONENV bash /run.sh backup" >> $CRONFILE
+  echo "$CRON_SCHEDULE root $CRONENV bash /run.sh backup" > $CRONFILE
 
   echo "Starting CRON scheduler: $(date)"
   cron


### PR DESCRIPTION
Restarting the container makes the run.sh script duplicate the entry in `cron.d`, which seems to break it and stop it from syncing because of the locking mechanism.

![image](https://user-images.githubusercontent.com/6237359/139286410-19e49177-9ca7-4de4-9d0d-967e485d20c6.png)

The fix should be as simple as making run.sh overwrite the file instead of appending to it.