### PR TITLE
Remove previous cron entries on start to ensure no duplicates of save…

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -36,7 +36,7 @@ if [[ $OPTION = "start" ]]; then
   CRONENV="$CRONENV AWS_DEFAULT_REGION=$REGION"
   CRONENV="$CRONENV S3PATH=$S3PATH"
   CRONENV="$CRONENV S3SYNCPARAMS=\"$S3SYNCPARAMS\""
-  echo "$CRON_SCHEDULE root $CRONENV bash /run.sh backup" >> $CRONFILE
+  echo "$CRON_SCHEDULE root $CRONENV bash /run.sh backup" > $CRONFILE
 
   echo "Starting CRON scheduler: $(date)"
   cron


### PR DESCRIPTION
…d settings

On every start of this container, the existing settings are appended tot he same cron file resulting in multiple jobs to run. 
Now only the most latest settings are persisted int he cron file

 Committer: Jason H <jason@developer.nz>